### PR TITLE
updates to use either PR1 or PR3 easily 

### DIFF
--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -40,14 +40,14 @@ message("ESMF_F90COMPILEPATHS:   ${ESMF_F90COMPILEPATHS}")
 #-------------------------
 # Determine switches
 #-------------------------
-list(APPEND switches "CESMCOUPLED" "NCO" "DIST" "MPI" "PR3" "UQ" "FLX0" "SEED" "ST4" "STAB0" "NL1" "BT1" "DB1" "MLIM" "FLD2" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB") 
+list(APPEND switches "CESMCOUPLED" "NCO" "DIST" "MPI" "PR3" "UQ" "FLX0" "SEED" "ST4" "STAB0" "NL1" "BT1" "DB1" "MLIM" "FLD2" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB" "IC4") 
 
-# TODO: need to enamble IC4 with the unstructured implemention  
 if (DEFINED USE_UNSTRUCT)
-  list(APPEND switches "IC0" "PDLIB" "METIS")
+  list(APPEND switches "PDLIB" "METIS")
 else()
-  list(APPEND switches "IC4" "OMPG"  "OMPH") 
+  list(APPEND switches "OMPG"  "OMPH") 
 endif()
+
 
 #-------------------------
 # Include list of src files to make file more readable
@@ -78,9 +78,14 @@ endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_switches.cmake)
 check_switches("${switches}" switch_files)
 
+message(STATUS "----SWITCHES-----")
+message(STATUS "switches are : ${switches}")
+message(STATUS "-----------------")
+
 message(STATUS "----status of source files-----")
 message(STATUS "list of always source files is : ${ftn_src}")
 message(STATUS "list of switch files is : ${switch_files}")
+message(STATUS "-----------------")
 
 #-------------------------
 # Now check in SourceMods to see if the file should be used instead

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -40,12 +40,20 @@ message("ESMF_F90COMPILEPATHS:   ${ESMF_F90COMPILEPATHS}")
 #-------------------------
 # Determine switches
 #-------------------------
-list(APPEND switches "CESMCOUPLED" "NCO" "DIST" "MPI" "PR3" "UQ" "FLX0" "SEED" "ST4" "STAB0" "NL1" "BT1" "DB1" "MLIM" "FLD2" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB" "IC4") 
+list(APPEND switches "CESMCOUPLED" "DIST" "MPI" "FLX0" "SEED" "ST4" "STAB0" "NL1" "BT1" "DB1" "MLIM" "FLD2" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB" "IC4")
+
+if (DEFINED USE_PR3)
+  list(APPEND switches PR3 UQ "NCO" )
+elseif (DEFINED USE_PR1)
+  list(APPEND switches PR1)
+else()
+  message(FATAL_ERROR "either USE_PR3 or USE_PR1 must be defined")
+endif()
 
 if (DEFINED USE_UNSTRUCT)
   list(APPEND switches "PDLIB" "METIS")
 else()
-  list(APPEND switches "OMPG"  "OMPH") 
+  list(APPEND switches "OMPG"  "OMPH")
 endif()
 
 
@@ -75,17 +83,14 @@ endif()
 # Determine switch specific files
 # Include check_switches as a function for less verbosity in this CMakeLists.txt
 #-------------------------
+message(STATUS "switches are : ${switches}")
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_switches.cmake)
 check_switches("${switches}" switch_files)
 
-message(STATUS "----SWITCHES-----")
-message(STATUS "switches are : ${switches}")
-message(STATUS "-----------------")
-
-message(STATUS "----status of source files-----")
+message(STATUS "---")
 message(STATUS "list of always source files is : ${ftn_src}")
 message(STATUS "list of switch files is : ${switch_files}")
-message(STATUS "-----------------")
+message(STATUS "---")
 
 #-------------------------
 # Now check in SourceMods to see if the file should be used instead

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -40,10 +40,10 @@ message("ESMF_F90COMPILEPATHS:   ${ESMF_F90COMPILEPATHS}")
 #-------------------------
 # Determine switches
 #-------------------------
-list(APPEND switches "CESMCOUPLED" "DIST" "MPI" "FLX0" "SEED" "ST4" "STAB0" "NL1" "BT1" "DB1" "MLIM" "FLD2" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB" "IC4")
+list(APPEND switches "CESMCOUPLED" "DIST" "MPI" "FLX0" "SEED" "ST4" "STAB0" "NL1" "BT1" "DB1" "MLIM" "FLD2" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB" "IC4" "NCO")
 
 if (DEFINED USE_PR3)
-  list(APPEND switches PR3 UQ "NCO" )
+  list(APPEND switches PR3 UQ)
 elseif (DEFINED USE_PR1)
   list(APPEND switches PR1)
 else()

--- a/model/src/w3src4md.F90
+++ b/model/src/w3src4md.F90
@@ -2225,8 +2225,16 @@ CONTAINS
       END DO
       !
       ! Computes Breaking probability
+      ! NOTE: for PR1 found that BTH occasionally went negative - so implemented the 
+      ! following fix for this
       !
-      PB = (MAX(SQRT(BTH)-EPSR,0.))**2
+      do ik = IK1,NK
+         if (BTH(ik) < 0.) then
+            PB(ik) = 0.
+         else
+            PB(ik) = (MAX(SQRT(BTH(ik))-EPSR,0.))**2
+         end if
+      end do
       !
       ! Multiplies by 28.16 = 22.0 * 1.6² * 1/2 with
       !  22.0 (Banner & al. 2000, figure 6)

--- a/model/src/wav_shel_inp.F90
+++ b/model/src/wav_shel_inp.F90
@@ -167,6 +167,7 @@ contains
     character(len=80)   :: linein
     character(len=30)   :: ofile ! w3_cou only
     character(len=8)    :: words(7)=''
+    character(len=256)  :: filename
     logical             :: flflg, flhom, tflagi, prtfrm, flgnml, flh(-7:10)
     integer             :: thrlev = 1
     integer             :: time0(2), timen(2), ttime(2)
@@ -259,29 +260,23 @@ contains
     !--------------------
 
 #ifndef W3_CESMCOUPLED
-    inquire(file=trim(fnmpre)//"ww3_shel.nml", exist=flgnml)
+    filename = trim(fnmpre)//"ww3_shel.nml"
 #else
-    inquire(file=trim(fnmpre)//"wav_in", exist=flgnml)
+    filename = trim(fnmpre)//"wav_in"
 #endif
 
+    inquire(file=trim(filename), exist=flgnml)
+
     if (flgnml) then
-#ifndef W3_CESMCOUPLED
-      open(newunit=ndsi, file=trim(fnmpre)//"ww3_shel.nml", status='old', iostat=ierr)
-#else
-      open(newunit=ndsi, file=trim(fnmpre)//"wav_in", status='old', iostat=ierr)
-#endif
+
+       open(newunit=ndsi, file=trim(filename), status='old', iostat=ierr)
 
       !--------------------
       ! Read namelist
       !--------------------
 
-#ifndef W3_CESMCOUPLED
-      call w3nmlshel (mpi_comm, ndsi, trim(fnmpre)//'ww3_shel.nml', nml_domain, nml_input, &
+      call w3nmlshel (mpi_comm, ndsi, trim(filename), nml_domain, nml_input, &
            nml_output_type, nml_output_date, nml_homog_count, nml_homog_input, ierr)
-#else
-      call w3nmlshel (mpi_comm, ndsi, trim(fnmpre)//'wav_in', nml_domain, nml_input, &
-           nml_output_type, nml_output_date, nml_homog_count, nml_homog_input, ierr)
-#endif
 
       !--------------------
       ! 2.1 forcing flags

--- a/model/src/wav_shel_inp.F90
+++ b/model/src/wav_shel_inp.F90
@@ -258,17 +258,30 @@ contains
     ! Read nml file if available
     !--------------------
 
+#ifndef W3_CESMCOUPLED
     inquire(file=trim(fnmpre)//"ww3_shel.nml", exist=flgnml)
+#else
+    inquire(file=trim(fnmpre)//"wav_in", exist=flgnml)
+#endif
 
     if (flgnml) then
+#ifndef W3_CESMCOUPLED
       open(newunit=ndsi, file=trim(fnmpre)//"ww3_shel.nml", status='old', iostat=ierr)
+#else
+      open(newunit=ndsi, file=trim(fnmpre)//"wav_in", status='old', iostat=ierr)
+#endif
 
       !--------------------
       ! Read namelist
       !--------------------
 
+#ifndef W3_CESMCOUPLED
       call w3nmlshel (mpi_comm, ndsi, trim(fnmpre)//'ww3_shel.nml', nml_domain, nml_input, &
            nml_output_type, nml_output_date, nml_homog_count, nml_homog_input, ierr)
+#else
+      call w3nmlshel (mpi_comm, ndsi, trim(fnmpre)//'wav_in', nml_domain, nml_input, &
+           nml_output_type, nml_output_date, nml_homog_count, nml_homog_input, ierr)
+#endif
 
       !--------------------
       ! 2.1 forcing flags


### PR DESCRIPTION
# Pull Request Summary
Update to use either PR1 or PR3 easily 

## Description
This PR updates CMakeLists.txt to use PR1 and PR3 easily (enhancement)
Also - provides a bugfix for running PR1 in debug mode (bug)

### Issue(s) addressed

### Commit Message
updates and bug fixes to use either PR1 or PR3 easily 

### Testing
Ran the following tests:
SMS_D_Ld5.T62_wtn14nw.WW3test.betzy_intel
ERS_D_Ld5.T62_wtn14.WW3test.betzy_intel
