### PR TITLE
fix for history output given current namelist for noresm

### DIFF
--- a/model/src/wav_shel_inp.F90
+++ b/model/src/wav_shel_inp.F90
@@ -132,6 +132,7 @@ contains
     use w3wdatmd       , only : qi5tbeg
 #endif
     use wav_kind_mod  , only : CL => shr_kind_cl
+    use w3odatmd      , only : use_historync
 
     ! input/output parameters
     integer,           intent(in) :: mpi_comm
@@ -527,6 +528,11 @@ contains
       if (w3_cou_flag) then
         notype = 7
       end if
+      ! history frequency is determined by history_n and history_option
+      if (use_historync .and. odat(3) .eq. 0) then
+        fldout = nml_output_type%field%list
+      end if
+
       do j = 1, notype
 
         ! outpts(i)%ofiles(j)=ofiles(j)


### PR DESCRIPTION
# Pull Request Summary
This adds history fields back into the ww3 history file given removal of the namelist group output_date_nml from the namelist (which is not needed for noresm)

### Testing

Ran the following case and verified that the ww3 history field contained the correct fields.

./create_newcase --case test_ww3_histflds 
--compset 20TR_DATM%JRA-1p4-2018_SLND_SICE_SOCN_SROF_SGLC_WW3 
--mach betzy --res T62_tn14_wtn14nw --project nn9560k --run-unsupported
