### PR TITLE
additional fix for having output fields set by buildnml hist_n and hist_option

### DIFF
--- a/model/src/wav_shel_inp.F90
+++ b/model/src/wav_shel_inp.F90
@@ -531,6 +531,7 @@ contains
       ! history frequency is determined by history_n and history_option
       if (use_historync .and. odat(3) .eq. 0) then
         fldout = nml_output_type%field%list
+        call w3flgrdflag ( ndso, ndso, ndse, fldout, flgd, flgrd, iaproc, napout, ierr )
       end if
 
       do j = 1, notype


### PR DESCRIPTION
# Pull Request Summary
additional fix for having output fields set by buildnml hist_n and hist_option
this change was provided by @DeniseWorthen

### Testing
Using noresm3_0_alpha03d with these changes - verified that history output for ww3 is indeed valid if 
hist_n=1 and hist_option=ndays
